### PR TITLE
Update README.md to provide current command to install bindgen on mac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,8 @@ There are two modules to handle that:
 
 ```bash
 # Install `bindgen`:
-cargo install bindgen
+cargo install bindgen-cli
+
 
 #
 # bindgen [FLAGS] [OPTIONS] <header> -- <clang-args>...


### PR DESCRIPTION
The current README.md states that bindgen can be installed with

`cargo install bindgen`

However, that command now fails on MacOS and Ubuntu with the following error:

```
cargo install bindgen
    Updating crates.io index
error: there is nothing to install in `bindgen v0.71.1`, because it has no binaries
`cargo install` is only for installing programs, and can't be used with libraries.
To use a library crate, add it as a dependency to a Cargo project with `cargo add`.
```

The following command succeeded on MacOS and on Ubuntu:

`cargo install bindgen-cli`

The P/R simply updates the README.md file to recommend the approach that now works.

TY for a great tutorial!!!